### PR TITLE
feat: add --snapshot and --env flags to sandbox create

### DIFF
--- a/packages/cli/src/sandbox/create.ts
+++ b/packages/cli/src/sandbox/create.ts
@@ -44,6 +44,23 @@ export async function create_sandbox(
 ): Promise<Sandbox> {
 	const daytona = create_daytona_client();
 
+	// If snapshot provided, use it directly (fast path)
+	if (options.snapshot) {
+		const sandbox = await daytona.create(
+			{
+				snapshot: options.snapshot,
+				language: 'typescript',
+				envVars: options.env_vars,
+				labels: options.labels,
+				autoStopInterval: options.auto_stop_interval,
+			},
+			{
+				timeout: options.timeout ?? DEFAULT_TIMEOUT,
+			},
+		);
+		return new Sandbox(daytona, sandbox);
+	}
+
 	// Determine the image to use
 	let image: string | Image;
 

--- a/packages/cli/src/sandbox/types.ts
+++ b/packages/cli/src/sandbox/types.ts
@@ -9,6 +9,8 @@ import type { Image } from '@daytonaio/sdk';
  * Options for creating a sandbox
  */
 export interface CreateSandboxOptions {
+	/** Snapshot name to use (skips image building) */
+	snapshot?: string;
 	/** Docker image name or Daytona Image object */
 	image?: string | Image;
 	/** Additional dockerfile commands to run */


### PR DESCRIPTION
## Summary
- Add `--snapshot` flag to use pre-built snapshots for fast sandbox creation
- Add `--env` flag to pass environment variables (e.g., `GH_TOKEN` for git auth)

Fixes #30

## Changes
- `packages/cli/src/commands/sandbox/create.ts` - Added --snapshot and --env CLI args
- `packages/cli/src/sandbox/create.ts` - Snapshot support in create_sandbox()
- `packages/cli/src/sandbox/types.ts` - Added snapshot field to CreateSandboxOptions

## Usage
```bash
# Fast creation from snapshot with git token
ralph-town sandbox create --snapshot ralph-town-dev --env "GH_TOKEN=$GH_TOKEN"
```

Enables proper dogfooding workflow where sandboxes have tools pre-installed and git credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)