### PR TITLE
fix: add PATH to SSH sessions in snapshot (#33)

### DIFF
--- a/packages/cli/src/core/create-snapshot.ts
+++ b/packages/cli/src/core/create-snapshot.ts
@@ -34,6 +34,13 @@ async function create_snapshot(): Promise<void> {
 			'curl -fsSL https://bun.sh/install | bash',
 			// Create working directory
 			'mkdir -p /home/daytona',
+			// Fix PATH for SSH sessions - multiple approaches for reliability:
+			// 1. /etc/environment - read by PAM for all sessions
+			'echo "PATH=/usr/local/bin:/usr/bin:/bin:/root/.bun/bin" > /etc/environment',
+			// 2. /etc/profile.d/ - for login shells
+			'echo "export PATH=/usr/local/bin:/usr/bin:/bin:/root/.bun/bin:\\$PATH" > /etc/profile.d/path.sh',
+			// 3. .bashrc - for interactive shells
+			'echo "export PATH=/usr/local/bin:/usr/bin:/bin:/root/.bun/bin:\\$PATH" >> /root/.bashrc',
 		)
 		.env({ PATH: '/root/.bun/bin:$PATH' })
 		.workdir('/home/daytona')


### PR DESCRIPTION
## Summary
- Fix SSH sessions having broken PATH (commands fail with exit 127)
- Set PATH in three locations during snapshot creation for reliability:
  - `/etc/environment` - read by PAM for all sessions
  - `/etc/profile.d/path.sh` - for login shells
  - `/root/.bashrc` - for interactive shells

## Test plan
- [ ] Delete existing snapshot: `daytona snapshot delete ralph-town-dev`
- [ ] Recreate snapshot: `bun run packages/cli/src/core/create-snapshot.ts`
- [ ] Create sandbox from new snapshot
- [ ] Test SSH command: `ssh token@host "ls"` (should work without full path)
- [ ] Test SSH command: `ssh token@host "git --version"` (should work)

**Note:** Existing sandboxes won't be fixed - need to recreate from new snapshot.

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)