### PR TITLE
fix: pass --name to Daytona SDK name field (#34)

### DIFF
--- a/packages/cli/src/commands/sandbox/create.ts
+++ b/packages/cli/src/commands/sandbox/create.ts
@@ -25,7 +25,7 @@ export default defineCommand({
 		},
 		name: {
 			type: 'string',
-			description: 'Sandbox name label',
+			description: 'Sandbox name',
 		},
 		'auto-stop': {
 			type: 'string',
@@ -67,11 +67,11 @@ export default defineCommand({
 
 		try {
 			const sandbox = await create_sandbox({
+				name: args.name,
 				snapshot: args.snapshot,
 				image: args.image,
 				auto_stop_interval: auto_stop,
 				timeout,
-				labels: args.name ? { name: args.name } : undefined,
 				env_vars: Object.keys(env_vars).length > 0 ? env_vars : undefined,
 				on_build_log: (args.json || args.snapshot) ? undefined : (chunk) => process.stdout.write(chunk),
 			});

--- a/packages/cli/src/sandbox/create.ts
+++ b/packages/cli/src/sandbox/create.ts
@@ -48,6 +48,7 @@ export async function create_sandbox(
 	if (options.snapshot) {
 		const sandbox = await daytona.create(
 			{
+				name: options.name,
 				snapshot: options.snapshot,
 				language: 'typescript',
 				envVars: options.env_vars,
@@ -88,6 +89,7 @@ export async function create_sandbox(
 
 	const sandbox = await daytona.create(
 		{
+			name: options.name,
 			image,
 			language: 'typescript',
 			envVars: options.env_vars,

--- a/packages/cli/src/sandbox/types.ts
+++ b/packages/cli/src/sandbox/types.ts
@@ -9,6 +9,8 @@ import type { Image } from '@daytonaio/sdk';
  * Options for creating a sandbox
  */
 export interface CreateSandboxOptions {
+	/** Sandbox name */
+	name?: string;
 	/** Snapshot name to use (skips image building) */
 	snapshot?: string;
 	/** Docker image name or Daytona Image object */


### PR DESCRIPTION
## Summary
- Fix `--name` flag not setting sandbox name
- Was passing name as `labels: { name }` instead of using SDK's `name` field
- Now passes `name` directly to `daytona.create()`

## Changes
- `packages/cli/src/sandbox/types.ts`: Add `name` to `CreateSandboxOptions`
- `packages/cli/src/commands/sandbox/create.ts`: Pass `name` instead of label
- `packages/cli/src/sandbox/create.ts`: Pass `name` to both create paths

## Test plan
- [ ] Create sandbox with name: `ralph-town sandbox create --name my-sandbox`
- [ ] List sandboxes: `ralph-town sandbox list`
- [ ] Verify sandbox shows with correct name

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)