### PR TITLE
feat: add gh CLI to snapshot for PR workflow (#32)

### DIFF
--- a/packages/cli/src/core/create-snapshot.ts
+++ b/packages/cli/src/core/create-snapshot.ts
@@ -25,11 +25,16 @@ async function create_snapshot(): Promise<void> {
 		// Snapshot doesn't exist, continue
 	}
 
-	// Build image with Bun + Claude Agent SDK
+	// Build image with Bun + Claude Agent SDK + gh CLI
 	const image = Image.base('debian:bookworm-slim')
 		.runCommands(
 			// Install dependencies
 			'apt-get update && apt-get install -y curl unzip git ca-certificates',
+			// Install gh CLI for PR workflow
+			'curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg',
+			'chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg',
+			'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null',
+			'apt-get update && apt-get install -y gh',
 			// Install Bun
 			'curl -fsSL https://bun.sh/install | bash',
 			// Create working directory


### PR DESCRIPTION
## Summary
- Add gh CLI installation to snapshot creation script
- Required for teammates to create PRs from sandboxes

## Changes
Install gh CLI via official GitHub apt repository during snapshot build.

## Test plan
- [ ] Delete existing snapshot: `daytona snapshot delete ralph-town-dev`
- [ ] Recreate: `bun run packages/cli/src/core/create-snapshot.ts`
- [ ] Create sandbox, SSH in
- [ ] Verify: `gh --version`
- [ ] Test PR workflow: `gh auth login && gh pr create`

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)