### PR TITLE
fix: read version from package.json instead of hardcoding

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,11 +6,12 @@
 
 import { defineCommand, runMain } from 'citty';
 import sandbox from './commands/sandbox/index.js';
+import pkg from '../package.json' with { type: 'json' };
 
 const main = defineCommand({
 	meta: {
 		name: 'ralph-town',
-		version: '0.0.1',
+		version: pkg.version,
 		description: 'Daytona-based agent orchestration',
 	},
 	subCommands: {

--- a/packages/mcp-ralph-town/src/server.ts
+++ b/packages/mcp-ralph-town/src/server.ts
@@ -7,6 +7,7 @@ import {
 	sandbox_delete_tool,
 	sandbox_exec_tool,
 } from './tools/index.js';
+import pkg from '../package.json' with { type: 'json' };
 
 export function create_server() {
 	const adapter = new ValibotJsonSchemaAdapter();
@@ -14,7 +15,7 @@ export function create_server() {
 	const server = new McpServer(
 		{
 			name: 'mcp-ralph-town',
-			version: '0.0.1',
+			version: pkg.version,
 			description:
 				'MCP server for Daytona sandbox management',
 		},


### PR DESCRIPTION
## Summary
- Import version from package.json in CLI (packages/cli/src/index.ts)
- Import version from package.json in MCP server (packages/mcp-ralph-town/src/server.ts)
- Uses ES module JSON import syntax: `import pkg from '../package.json' with { type: 'json' }`

## Test plan
- [x] Build passes (`bun run build`)
- [ ] Verify CLI shows correct version: `ralph-town --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)