### PR TITLE
fix: add MCP timeout and shutdown handlers

### DIFF
--- a/packages/mcp-ralph-town/src/index.ts
+++ b/packages/mcp-ralph-town/src/index.ts
@@ -6,4 +6,12 @@ import { create_server } from './server.js';
 const server = create_server();
 const transport = new StdioTransport(server);
 
+function handle_shutdown(signal: string) {
+	console.error(`Received ${signal}, shutting down gracefully...`);
+	process.exit(0);
+}
+
+process.on('SIGINT', () => handle_shutdown('SIGINT'));
+process.on('SIGTERM', () => handle_shutdown('SIGTERM'));
+
 transport.listen();


### PR DESCRIPTION
## Summary
- Add 300000ms (5 min) default timeout to run_cli in sandbox.ts
- Add SIGINT/SIGTERM handlers in index.ts for graceful shutdown

## Test plan
- Build project to verify no TypeScript errors
- Test MCP server shutdown with SIGINT/SIGTERM signals

Fixes #52
Fixes #53