### PR TITLE
fix: sanitize shell inputs in git-workflow and daytona runtime

### DIFF
--- a/packages/cli/src/core/utils.ts
+++ b/packages/cli/src/core/utils.ts
@@ -125,3 +125,19 @@ export function parse_int_flag_or_exit(
 		process.exit(1);
 	}
 }
+
+/**
+ * Escape a string for safe use in shell commands
+ * Uses single quotes and escapes any embedded single quotes
+ */
+export function shell_escape(str: string): string {
+	return `'${str.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Validate git branch name (reject unsafe characters)
+ * Allows alphanumeric, hyphens, underscores, slashes, dots
+ */
+export function validate_branch_name(branch: string): boolean {
+	return /^[a-zA-Z0-9_.\-/]+$/.test(branch) && !branch.includes('..');
+}


### PR DESCRIPTION
## Summary

- Add `shell_escape()` utility using single-quote escaping to prevent shell injection
- Add `validate_branch_name()` to reject unsafe branch names with special characters
- Fix `git-workflow.ts`: escape `repo_path` in `install_dependencies()`
- Fix `daytona.ts`: escape path in `file_exists()`
- Fix `daytona.ts`: validate branch name and escape paths in `create_worktree()`
- Fix `daytona.ts`: escape path in `remove_worktree()`

## Test plan

- [ ] Verify build passes
- [ ] Test with paths containing spaces/special chars
- [ ] Test with malformed branch names (rejected)

Fixes #70, Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)