### PR TITLE
feat: add sandbox-workflow skill

### DIFF
--- a/.claude/skills/sandbox-workflow/SKILL.md
+++ b/.claude/skills/sandbox-workflow/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: sandbox-workflow
+# prettier-ignore
+description: Use for teammate sandbox operations - SSH access, git workflow, full paths required
+---
+
+# Sandbox Workflow
+
+## Quick Start
+
+```bash
+# 1. Create sandbox with snapshot
+source .env
+ralph-town sandbox create --snapshot ralph-town-dev --env "GH_TOKEN=$GH_TOKEN"
+
+# 2. Get SSH access
+ralph-town sandbox ssh <sandbox-id>
+# Returns: ssh <token>@ssh.app.daytona.io
+
+# 3. Clean up when done
+ralph-town sandbox delete <sandbox-id>
+```
+
+## Core Principles
+
+- Work dir is `/home/daytona` - NOT `/workspaces`
+- **ALWAYS use full paths**: `/usr/bin/git`, `/usr/bin/gh`, `/bin/ls`
+- **ALWAYS use --snapshot flag** when creating sandboxes
+- Source `.env` before create so `$GH_TOKEN` expands
+
+## References
+
+- [ssh-gotchas.md](references/ssh-gotchas.md) - PATH and environment issues
+- [git-workflow.md](references/git-workflow.md) - Clone, branch, PR flow
+- [common-mistakes.md](references/common-mistakes.md) - Avoid these errors

--- a/.claude/skills/sandbox-workflow/references/common-mistakes.md
+++ b/.claude/skills/sandbox-workflow/references/common-mistakes.md
@@ -1,0 +1,66 @@
+# Common Mistakes
+
+## 1. Missing --snapshot Flag
+
+Creates empty sandbox without tools installed.
+
+**BAD:**
+```bash
+ralph-town sandbox create --json
+```
+
+**GOOD:**
+```bash
+ralph-town sandbox create --snapshot ralph-town-dev --json
+```
+
+## 2. GH_TOKEN Not Expanded
+
+If you forget to source .env, the literal string `$GH_TOKEN` is passed.
+
+**BAD:**
+```bash
+ralph-town sandbox create --env "GH_TOKEN=$GH_TOKEN"
+```
+
+**GOOD:**
+```bash
+source .env
+ralph-town sandbox create --env "GH_TOKEN=$GH_TOKEN"
+```
+
+## 3. Using Short Commands
+
+PATH is broken in SSH sessions.
+
+**BAD:**
+```bash
+git status
+gh pr list
+```
+
+**GOOD:**
+```bash
+/usr/bin/git status
+/usr/bin/gh pr list
+```
+
+## 4. Wrong Working Directory
+
+**BAD:**
+```bash
+cd /workspaces
+```
+
+**GOOD:**
+```bash
+cd /home/daytona
+```
+
+## 5. Stale Snapshot
+
+If `gh` or other tools are missing, rebuild snapshot:
+
+```bash
+bun run packages/cli/src/core/create-snapshot.ts --force
+```

--- a/.claude/skills/sandbox-workflow/references/git-workflow.md
+++ b/.claude/skills/sandbox-workflow/references/git-workflow.md
@@ -1,0 +1,45 @@
+# Git Workflow in Sandbox
+
+## Clone Repository
+
+```bash
+cd /home/daytona
+/usr/bin/git clone https://$GH_TOKEN@github.com/owner/repo.git
+cd repo
+```
+
+## Create Feature Branch
+
+```bash
+/usr/bin/git checkout -b feat/branch-name
+# or for fixes:
+/usr/bin/git checkout -b fix/issue-description
+```
+
+## Commit and Push
+
+```bash
+/usr/bin/git add -A
+/usr/bin/git commit -m "feat: description of change"
+/usr/bin/git push -u origin feat/branch-name
+```
+
+## Create Pull Request
+
+```bash
+/usr/bin/gh pr create \
+  --title "feat: short description" \
+  --body "Description here
+
+Fixes #N"
+```
+
+## Multiple Tasks
+
+For each new task, start fresh from main:
+
+```bash
+/usr/bin/git checkout main
+/usr/bin/git pull
+/usr/bin/git checkout -b feat/next-task
+```

--- a/.claude/skills/sandbox-workflow/references/ssh-gotchas.md
+++ b/.claude/skills/sandbox-workflow/references/ssh-gotchas.md
@@ -1,0 +1,33 @@
+# SSH Gotchas
+
+## PATH is Broken
+
+The sandbox SSH session has a minimal PATH. Commands like `git`, `gh`,
+`ls` will fail with "command not found".
+
+**Solution**: Always use full paths:
+
+| Command | Full Path |
+|---------|-----------|
+| git | `/usr/bin/git` |
+| gh | `/usr/bin/gh` |
+| ls | `/bin/ls` |
+| cat | `/bin/cat` |
+| mkdir | `/bin/mkdir` |
+| rm | `/bin/rm` |
+| bun | `/root/.bun/bin/bun` |
+
+## Working Directory
+
+- Default: `/home/daytona`
+- **NOT** `/workspaces` (common misconception)
+
+## Environment Variables
+
+- `$GH_TOKEN` is available if passed via `--env` flag during create
+- Other env vars may not be present
+
+## Exit Codes
+
+SSH commands may return exit code 255 even on success - check actual
+output for errors.


### PR DESCRIPTION
Adds skill for teammate sandbox operations.

## Contents

- SKILL.md - Quick start and core principles
- references/ssh-gotchas.md - PATH and environment issues
- references/git-workflow.md - Clone, branch, PR flow
- references/common-mistakes.md - Avoid these errors

Fixes #8