### PR TITLE
fix: standardize exit code handling

### DIFF
--- a/packages/cli/src/commands/sandbox/create.ts
+++ b/packages/cli/src/commands/sandbox/create.ts
@@ -76,7 +76,8 @@ export default defineCommand({
 				} else {
 					console.error('Error: ' + msg);
 				}
-				process.exit(1);
+				process.exitCode = 1;
+				return;
 			}
 		}
 
@@ -146,7 +147,8 @@ export default defineCommand({
 				} else {
 					console.error('Error: ' + error.message);
 				}
-				process.exit(1);
+				process.exitCode = 1;
+				return;
 			}
 			throw error;
 		}

--- a/packages/cli/src/commands/sandbox/delete.ts
+++ b/packages/cli/src/commands/sandbox/delete.ts
@@ -41,7 +41,8 @@ export default defineCommand({
 				} else {
 					console.error('Error: ' + error.message);
 				}
-				process.exit(1);
+				process.exitCode = 1;
+				return;
 			}
 			throw error;
 		}
@@ -83,7 +84,8 @@ export default defineCommand({
 			} else {
 				console.error('Error deleting sandbox: ' + message);
 			}
-			process.exit(1);
+			process.exitCode = 1;
+			return;
 		}
 	},
 });

--- a/packages/cli/src/commands/sandbox/exec.ts
+++ b/packages/cli/src/commands/sandbox/exec.ts
@@ -50,7 +50,8 @@ export default defineCommand({
 				} else {
 					console.error('Error: ' + error.message);
 				}
-				process.exit(1);
+				process.exitCode = 1;
+				return;
 			}
 			throw error;
 		}
@@ -81,7 +82,8 @@ export default defineCommand({
 				console.log(result.result);
 			}
 			if (result.exitCode !== 0) {
-				process.exit(result.exitCode);
+				process.exitCode = result.exitCode;
+				return;
 			}
 		}
 	},

--- a/packages/cli/src/commands/sandbox/list.ts
+++ b/packages/cli/src/commands/sandbox/list.ts
@@ -36,7 +36,8 @@ export default defineCommand({
 				} else {
 					console.error('Error: ' + error.message);
 				}
-				process.exit(1);
+				process.exitCode = 1;
+				return;
 			}
 			throw error;
 		}

--- a/packages/cli/src/commands/sandbox/preflight.ts
+++ b/packages/cli/src/commands/sandbox/preflight.ts
@@ -152,7 +152,8 @@ export default defineCommand({
 					console.log(
 						'  bun run packages/cli/src/core/create-snapshot.ts --force',
 					);
-					process.exit(1);
+					process.exitCode = 1;
+					return;
 				}
 			}
 		} catch (error) {
@@ -180,7 +181,8 @@ export default defineCommand({
 			} else {
 				console.error(`\n\x1b[31mError: ${message}\x1b[0m`);
 			}
-			process.exit(1);
+			process.exitCode = 1;
+			return;
 		}
 	},
 });

--- a/packages/cli/src/commands/sandbox/snapshot/create.ts
+++ b/packages/cli/src/commands/sandbox/snapshot/create.ts
@@ -30,7 +30,7 @@ export default defineCommand({
 	async run({ args }) {
 		const snapshot_name = args.name || DEFAULT_SNAPSHOT_NAME;
 
-		if (\!args.json) {
+		if (!args.json) {
 			console.log(`Creating snapshot: ${snapshot_name}\n`);
 		}
 
@@ -40,18 +40,18 @@ export default defineCommand({
 		try {
 			const existing = await daytona.snapshot.get(snapshot_name);
 			if (args.force) {
-				if (\!args.json) {
+				if (!args.json) {
 					console.log(
 						`Snapshot exists (state: ${existing.state}), deleting...`,
 					);
 				}
 				await daytona.snapshot.delete(existing);
 				// Wait for deletion to propagate
-				if (\!args.json) {
+				if (!args.json) {
 					console.log('Waiting for deletion to complete...');
 				}
 				await new Promise((resolve) => setTimeout(resolve, 5000));
-				if (\!args.json) {
+				if (!args.json) {
 					console.log('Deleted existing snapshot.\n');
 				}
 			} else {
@@ -100,7 +100,7 @@ export default defineCommand({
 				'/root/.bun/bin/bun add @anthropic-ai/claude-agent-sdk',
 			);
 
-		if (\!args.json) {
+		if (!args.json) {
 			console.log('Building snapshot (this takes ~2-3 minutes)...\n');
 		}
 
@@ -122,7 +122,7 @@ export default defineCommand({
 					}),
 				);
 			} else {
-				console.log(`\nSnapshot created successfully\!`);
+				console.log(`\nSnapshot created successfully!`);
 				console.log(`  Name: ${snapshot.name}`);
 				console.log(`  ID: ${snapshot.id}`);
 				console.log(`  State: ${snapshot.state}`);
@@ -133,9 +133,10 @@ export default defineCommand({
 					JSON.stringify({ error: error instanceof Error ? error.message : String(error) }),
 				);
 			} else {
-				console.error('\\nFailed to create snapshot:', error);
+				console.error('\nFailed to create snapshot:', error);
 			}
-			process.exit(1);
+			process.exitCode = 1;
+			return;
 		}
 	},
 });

--- a/packages/cli/src/commands/sandbox/ssh.ts
+++ b/packages/cli/src/commands/sandbox/ssh.ts
@@ -46,7 +46,8 @@ export default defineCommand({
 				} else {
 					console.error('Error: ' + error.message);
 				}
-				process.exit(1);
+				process.exitCode = 1;
+				return;
 			}
 			throw error;
 		}

--- a/packages/cli/src/sandbox/sandbox.ts
+++ b/packages/cli/src/sandbox/sandbox.ts
@@ -115,3 +115,32 @@ export class Sandbox {
 
 	/**
 	 * Delete the sandbox
+	 * @param timeout - Timeout in seconds (default: 60)
+	 */
+	async delete(timeout: number = 60): Promise<void> {
+		await this.sandbox.delete(timeout);
+	}
+
+	/**
+	 * Get the working directory path
+	 * @returns Working directory path
+	 */
+	async get_work_dir(): Promise<string | undefined> {
+		return this.sandbox.getWorkDir();
+	}
+
+	/**
+	 * Get the user's home directory path
+	 * @returns Home directory path
+	 */
+	async get_home_dir(): Promise<string | undefined> {
+		return this.sandbox.getUserHomeDir();
+	}
+
+	/**
+	 * Access the underlying Daytona sandbox for advanced operations
+	 */
+	get raw(): DaytonaSandbox {
+		return this.sandbox;
+	}
+}


### PR DESCRIPTION
## Summary
- Replaces `process.exit(1)` with `process.exitCode = 1; return;` in all command files
- This allows cleanup handlers to run properly

## Also fixes
- **PR #84 regression**: sandbox.ts was truncated (missing delete, get_work_dir, get_home_dir, raw methods)
- **PR #87 regression**: snapshot/create.ts had escaped characters (`\!` instead of `!`)

## Files changed
- packages/cli/src/commands/sandbox/*.ts - exit code standardization
- packages/cli/src/commands/sandbox/snapshot/create.ts - exit codes + escape fixes
- packages/cli/src/sandbox/sandbox.ts - restore truncated methods

Fixes #56

---
Generated with [Claude Code](https://claude.com/claude-code)