### PR TITLE
docs: document exec -1 limitation

### DIFF
--- a/packages/cli/src/commands/sandbox/exec.ts
+++ b/packages/cli/src/commands/sandbox/exec.ts
@@ -63,6 +63,10 @@ export default defineCommand({
 			args.json,
 		);
 
+		// KNOWN ISSUE: executeCommand returns exit code -1 with empty stdout
+		// on snapshot-based sandboxes. This is a Daytona SDK bug.
+		// Workaround: Use SSH instead (see sandbox ssh command).
+		// Upstream issue: https://github.com/daytonaio/daytona/issues/2283
 		const result = await sandbox.process.executeCommand(
 			args.cmd,
 			args.cwd,


### PR DESCRIPTION
Fixes #31

## Summary
- Adds a code comment in exec.ts explaining the executeCommand -1 exit code limitation
- Documents the SSH workaround
- Links to upstream Daytona issue daytonaio/daytona#2283

## Test plan
- Review the added comment in packages/cli/src/commands/sandbox/exec.ts
- Verify CLAUDE.md already documents this known issue