### PR TITLE
docs: fix MCP README tool names

### DIFF
--- a/packages/mcp-ralph-town/README.md
+++ b/packages/mcp-ralph-town/README.md
@@ -1,7 +1,7 @@
 # mcp-ralph-town
 
-MCP server wrapping the Ralph Loop CLI for autonomous agent
-orchestration.
+MCP server wrapping the Ralph Town CLI for Daytona sandbox
+management.
 
 ## Installation
 
@@ -26,9 +26,13 @@ Add to your Claude Code MCP config:
 
 ## Tools
 
-- `ralph_init` - Initialize ralph.json config
-- `ralph_run` - Run Ralph Loop orchestration
-- `ralph_validate` - Validate ralph.json config
+- `sandbox_create` - Create a new Daytona sandbox
+- `sandbox_list` - List active sandboxes
+- `sandbox_ssh` - Get SSH credentials for a sandbox
+- `sandbox_delete` - Delete a sandbox
+- `sandbox_exec` - Execute command in a sandbox
+- `sandbox_env_list` - List environment variables for a sandbox
+- `sandbox_env_set` - Set environment variable for a sandbox
 
 ## License
 


### PR DESCRIPTION
Fixes #100

Updates the tool names in the MCP README to match the actual implementations:
- sandbox_create
- sandbox_list  
- sandbox_ssh
- sandbox_delete
- sandbox_exec
- sandbox_env_list
- sandbox_env_set