### PR TITLE
feat: add input validation for sandbox names

### DIFF
--- a/packages/cli/src/sandbox/create.ts
+++ b/packages/cli/src/sandbox/create.ts
@@ -7,6 +7,7 @@ import { Image } from '@daytonaio/sdk';
 import { create_daytona_client } from './client.js';
 import { Sandbox } from './sandbox.js';
 import type { CreateSandboxOptions } from './types.js';
+import { validate_sandbox_name } from './validation.js';
 
 /** Default base image for sandboxes */
 const DEFAULT_BASE_IMAGE = 'node:22-slim';
@@ -42,6 +43,11 @@ export function create_default_image(
 export async function create_sandbox(
 	options: CreateSandboxOptions = {},
 ): Promise<Sandbox> {
+	// Validate sandbox name if provided
+	if (options.name) {
+		validate_sandbox_name(options.name);
+	}
+
 	const daytona = create_daytona_client();
 
 	// If snapshot provided, use it directly (fast path)

--- a/packages/cli/src/sandbox/index.ts
+++ b/packages/cli/src/sandbox/index.ts
@@ -11,3 +11,6 @@ export { Sandbox } from './sandbox.js';
 export type {
 	CreateSandboxOptions, ExecuteResult, SshAccess
 } from './types.js';
+export {
+	SandboxNameValidationError, validate_sandbox_name
+} from './validation.js';

--- a/packages/cli/src/sandbox/validation.ts
+++ b/packages/cli/src/sandbox/validation.ts
@@ -1,0 +1,49 @@
+/**
+ * Sandbox Name Validation
+ * Validates sandbox names to prevent issues with special characters
+ */
+
+/** Minimum length for sandbox names */
+const MIN_NAME_LENGTH = 1;
+
+/** Maximum length for sandbox names (DNS label limit) */
+const MAX_NAME_LENGTH = 63;
+
+/** Pattern for valid sandbox names: alphanumeric and hyphens, no leading/trailing hyphens */
+const VALID_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i;
+
+/**
+ * Validation error for sandbox names
+ */
+export class SandboxNameValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'SandboxNameValidationError';
+	}
+}
+
+/**
+ * Validate a sandbox name
+ * @param name - The name to validate
+ * @throws SandboxNameValidationError if invalid
+ */
+export function validate_sandbox_name(name: string): void {
+	if (!name || name.length < MIN_NAME_LENGTH) {
+		throw new SandboxNameValidationError(
+			`Sandbox name must be at least ${MIN_NAME_LENGTH} character(s)`,
+		);
+	}
+
+	if (name.length > MAX_NAME_LENGTH) {
+		throw new SandboxNameValidationError(
+			`Sandbox name must be at most ${MAX_NAME_LENGTH} characters (got ${name.length})`,
+		);
+	}
+
+	if (!VALID_NAME_PATTERN.test(name)) {
+		throw new SandboxNameValidationError(
+			'Sandbox name must contain only alphanumeric characters and hyphens, ' +
+				'and cannot start or end with a hyphen',
+		);
+	}
+}


### PR DESCRIPTION
Adds validation for sandbox names to prevent issues with special characters.

## Changes
- New `validation.ts` module with `validate_sandbox_name()` function
- Validates names: alphanumeric + hyphens only, 1-63 chars, no leading/trailing hyphens
- `SandboxNameValidationError` for descriptive error messages
- Validation called in `create_sandbox()` before SDK call
- Exports added to `index.ts`

Fixes #113