### PR TITLE
fix: use credential helper instead of tokens in git URLs

### DIFF
--- a/.claude/skills/daytona-sdk/references/api-gotchas.md
+++ b/.claude/skills/daytona-sdk/references/api-gotchas.md
@@ -11,13 +11,23 @@ When working in a sandbox via SSH:
 **JUST RUN:**
 ```bash
 cd /home/daytona
-/usr/bin/git clone https://$GH_TOKEN@github.com/owner/repo.git
+
+# Setup credentials FIRST (secure - keeps token out of URLs/logs)
+/usr/bin/git config --global credential.helper store
+echo "https://oauth2:$GH_TOKEN@github.com" > ~/.git-credentials
+
+# Clone WITHOUT token in URL
+/usr/bin/git clone https://github.com/owner/repo.git
 ```
 
 **DON'T WASTE TIME ON:**
 - `echo $GH_TOKEN` - it's there, trust it
 - `which git` - PATH is broken, use full paths
 - checking if commands exist - just run them
+
+**DON'T PUT TOKEN IN URL:**
+- BAD: `git clone https://$GH_TOKEN@github.com/...` (leaks to logs)
+- GOOD: Use credential helper as shown above
 
 ## CLI: Environment Variables Must Be Sourced
 

--- a/.claude/skills/sandbox-teammate/SKILL.md
+++ b/.claude/skills/sandbox-teammate/SKILL.md
@@ -9,10 +9,19 @@
 curl -sL https://github.com/cli/cli/releases/download/v2.65.0/gh_2.65.0_linux_amd64.tar.gz | tar -xz -C /tmp && mkdir -p ~/bin && mv /tmp/gh_*/bin/gh ~/bin/
 ```
 
-## Setup
+## Setup Credentials (SECURE)
 
 ```bash
-git clone https://$GH_TOKEN@github.com/spences10/ralph-town.git
+# Configure credential helper (keeps token out of URLs/logs)
+git config --global credential.helper store
+echo "https://oauth2:$GH_TOKEN@github.com" > ~/.git-credentials
+```
+
+## Clone Repository
+
+```bash
+# Clone WITHOUT token in URL
+git clone https://github.com/spences10/ralph-town.git
 cd ralph-town
 ```
 
@@ -39,3 +48,4 @@ git push -u origin fix/your-branch-name
 2. **Install gh first** - snapshot may not have it
 3. **GH_TOKEN is available** - don't check, just use it
 4. **Don't run `which` or `echo $VAR`** - wastes time
+5. **Use credential helper** - never put token in git URLs

--- a/.claude/skills/sandbox-workflow/references/git-workflow.md
+++ b/.claude/skills/sandbox-workflow/references/git-workflow.md
@@ -1,10 +1,26 @@
 # Git Workflow in Sandbox
 
+## Setup Credentials (SECURE)
+
+Before cloning, configure git to use credential helper:
+
+```bash
+# Configure credential helper (one-time setup)
+/usr/bin/git config --global credential.helper store
+echo "https://oauth2:$GH_TOKEN@github.com" > ~/.git-credentials
+```
+
+This stores credentials securely - tokens never appear in:
+- Command line (process list)
+- Shell history
+- Error messages or logs
+
 ## Clone Repository
 
 ```bash
 cd /home/daytona
-/usr/bin/git clone https://$GH_TOKEN@github.com/owner/repo.git
+# Clone WITHOUT token in URL
+/usr/bin/git clone https://github.com/owner/repo.git
 cd repo
 ```
 

--- a/.claude/skills/teammate-setup/SKILL.md
+++ b/.claude/skills/teammate-setup/SKILL.md
@@ -43,8 +43,12 @@ Send these instructions to the teammate:
 # Install gh CLI (required for PRs)
 curl -sL https://github.com/cli/cli/releases/download/v2.65.0/gh_2.65.0_linux_amd64.tar.gz | tar -xz -C /tmp && mkdir -p ~/bin && mv /tmp/gh_*/bin/gh ~/bin/
 
-# Clone repository with authentication
-git clone https://$GH_TOKEN@github.com/<owner>/<repo>.git
+# Configure git credential helper (SECURE - token not in URLs/logs)
+git config --global credential.helper store
+echo "https://oauth2:$GH_TOKEN@github.com" > ~/.git-credentials
+
+# Clone repository (no token in URL needed)
+git clone https://github.com/<owner>/<repo>.git
 cd <repo>
 
 # Configure git identity
@@ -90,10 +94,13 @@ When assigning a teammate to work in a sandbox, send them:
 **Setup Steps:**
 1. SSH into your sandbox
 2. Install gh CLI (see command above)
-3. Clone repo: `git clone https://$GH_TOKEN@github.com/<owner>/<repo>.git`
-4. cd <repo>
-5. Configure git: `git config user.email "claude@anthropic.com" && git config user.name "Claude"`
-6. Create branch: `git checkout -b <branch-type>/<branch-name>`
+3. Configure credentials:
+   `git config --global credential.helper store`
+   `echo "https://oauth2:$GH_TOKEN@github.com" > ~/.git-credentials`
+4. Clone repo: `git clone https://github.com/<owner>/<repo>.git`
+5. cd <repo>
+6. Configure git: `git config user.email "claude@anthropic.com" && git config user.name "Claude"`
+7. Create branch: `git checkout -b <branch-type>/<branch-name>`
 
 **After completing work:**
 - Commit, push, and create PR with gh CLI
@@ -117,5 +124,6 @@ When assigning a teammate to work in a sandbox, send them:
 | Get SSH             | `ralph-town sandbox ssh <id>`                  |
 | Delete sandbox      | `ralph-town sandbox delete <id>`               |
 | Install gh          | `curl -sL ... \| tar ... && mv ...`            |
-| Clone with auth     | `git clone https://$GH_TOKEN@github.com/...`   |
+| Setup credentials   | `git config ... && echo ... > ~/.git-credentials` |
+| Clone repo          | `git clone https://github.com/...`             |
 | Create PR           | `~/bin/gh pr create --title "..." --body "..."` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,13 @@ ralph-town sandbox ssh <sandbox-id>
 # 3. SSH in and work (USE FULL PATHS - PATH is broken)
 ssh <token>@ssh.app.daytona.io
 cd /home/daytona
-/usr/bin/git clone https://$GH_TOKEN@github.com/owner/repo.git
+
+# Configure git credential helper (SECURE - token not in URL/logs)
+/usr/bin/git config --global credential.helper store
+echo "https://oauth2:$GH_TOKEN@github.com" > ~/.git-credentials
+
+# Clone WITHOUT token in URL
+/usr/bin/git clone https://github.com/owner/repo.git
 cd repo
 /usr/bin/git config user.email "teammate@example.com"
 /usr/bin/git config user.name "teammate"
@@ -71,6 +77,10 @@ SSH sessions have broken PATH. ALWAYS use full paths:
 4. **GH_TOKEN not expanded** - must source .env first
    - BAD: `sandbox create --env "GH_TOKEN=$GH_TOKEN"` (without source)
    - GOOD: `source .env && sandbox create --env "GH_TOKEN=$GH_TOKEN"`
+
+5. **Token in git URL** - leaks to logs/process list
+   - BAD: `git clone https://$GH_TOKEN@github.com/...`
+   - GOOD: Use credential helper (see workflow above)
 
 ### PR Best Practices
 


### PR DESCRIPTION
## Summary
- Replace all documentation recommending token-in-URL pattern with secure credential helper approach
- Tokens in URLs like `git clone https://$TOKEN@github.com/...` leak via process list, shell history, error messages, and logs

## Changes
Updated these files to use credential helper instead:
- CLAUDE.md
- docs/RESEARCH.md
- .claude/skills/sandbox-workflow/references/git-workflow.md
- .claude/skills/daytona-sdk/references/api-gotchas.md
- .claude/skills/teammate-setup/SKILL.md  
- .claude/skills/sandbox-teammate/SKILL.md

## Secure Pattern
```bash
git config --global credential.helper store
echo "https://oauth2:$GH_TOKEN@github.com" > ~/.git-credentials
git clone https://github.com/owner/repo.git  # no token in URL
```

Fixes #99

## Test Plan
- [ ] Verify credential helper works in sandbox SSH session
- [ ] Confirm git push/pull work without token in URL
- [ ] Check no sensitive data in process list during git operations