### PR TITLE
feat: add teammate-prompt skill for sandbox workers

### DIFF
--- a/.claude/skills/teammate-prompt/SKILL.md
+++ b/.claude/skills/teammate-prompt/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: teammate-prompt
+# prettier-ignore
+description: Generate prompts for sandbox teammates. Use when spawning teammates to work on issues in Daytona sandboxes.
+---
+
+# Teammate Prompt Generator
+
+Generate consistent prompts for teammates working in Daytona
+sandboxes.
+
+## Core Rules for Teammates
+
+1. **Sandbox-only work** - NEVER use local Read/Write/Edit tools
+2. **Fail fast** - Report errors to team-lead immediately, don't retry
+3. **Full paths** - `/usr/bin/git`, `/usr/bin/gh`,
+   `/root/.bun/bin/bun`
+
+## Prompt Template
+
+```
+You are teammate "{{NAME}}" on team "{{TEAM}}".
+
+## CRITICAL RULES
+1. ONLY work inside sandbox via SSH - NEVER use local filesystem tools
+2. Fail fast - report errors to team-lead immediately, don't retry
+3. Full paths required: /usr/bin/git, /usr/bin/gh, /root/.bun/bin/bun
+
+## Your Task
+{{ISSUE_TITLE}} (Task ID: {{TASK_ID}})
+
+## Sandbox
+- SSH: ssh {{SSH_TOKEN}}@ssh.app.daytona.io
+- ID: {{SANDBOX_ID}}
+
+## Setup
+ssh {{SSH_TOKEN}}@ssh.app.daytona.io
+cd /home/daytona
+/usr/bin/git clone https://github.com/{{REPO}}.git
+cd {{REPO_NAME}}
+/usr/bin/git config user.email "claude@anthropic.com"
+/usr/bin/git config user.name "Claude"
+/usr/bin/git checkout -b {{BRANCH}}
+
+## Implementation
+{{TASK_DESCRIPTION}}
+
+## After Completing
+1. /usr/bin/git add -A && /usr/bin/git commit -m "{{COMMIT_MSG}}"
+2. /usr/bin/git push -u origin {{BRANCH}}
+3. /usr/bin/gh pr create --title "{{PR_TITLE}}" --body "Fixes #{{ISSUE_NUM}}"
+4. Mark task completed + send PR URL to team-lead
+```
+
+## References
+
+- [variables.md](references/variables.md) - All template variables
+- [examples.md](references/examples.md) - Complete prompt examples

--- a/.claude/skills/teammate-prompt/references/examples.md
+++ b/.claude/skills/teammate-prompt/references/examples.md
@@ -1,0 +1,90 @@
+# Prompt Examples
+
+## Example: Bug Fix
+
+```
+You are teammate "fix-98" on team "ralph-town-fixes".
+
+## CRITICAL RULES
+1. ONLY work inside sandbox via SSH - NEVER use local filesystem tools
+2. Fail fast - report errors to team-lead immediately, don't retry
+3. Full paths required: /usr/bin/git, /usr/bin/gh, /root/.bun/bin/bun
+
+## Your Task
+Fix #98 - SSH tokens exposed in JSON output (Task ID: 1)
+
+## Sandbox
+- SSH: ssh TS24aga1jLt47Hm7iwvDs8@ssh.app.daytona.io
+- ID: ded60781-9e71-4fd9-81f9-05f60154f786
+
+## Setup
+ssh TS24aga1jLt47Hm7iwvDs8@ssh.app.daytona.io
+cd /home/daytona
+/usr/bin/git clone https://$GH_TOKEN@github.com/spences10/ralph-town.git
+cd ralph-town
+/usr/bin/git config user.email "claude@anthropic.com"
+/usr/bin/git config user.name "Claude"
+/usr/bin/git checkout -b fix/98-redact-ssh-tokens
+
+## Implementation
+SSH tokens are exposed when MCP uses --json flag.
+
+Changes needed in packages/cli/src/commands/sandbox/ssh.ts:
+1. Add --show-secrets flag (default: false)
+2. Mask token in JSON output by default
+3. Add token_masked: true field
+
+## After Completing
+1. /usr/bin/git add -A && /usr/bin/git commit -m "fix: redact SSH tokens in JSON output"
+2. /usr/bin/git push -u origin fix/98-redact-ssh-tokens
+3. /usr/bin/gh pr create --title "fix: redact SSH tokens in JSON" --body "Fixes #98"
+4. Mark task #1 completed + send PR URL to team-lead
+```
+
+## Example: Documentation
+
+```
+You are teammate "docs-104" on team "ralph-town-docs".
+
+## CRITICAL RULES
+1. ONLY work inside sandbox via SSH - NEVER use local filesystem tools
+2. Fail fast - report errors to team-lead immediately, don't retry
+3. Full paths required: /usr/bin/git, /usr/bin/gh
+
+## Your Task
+Fix #104 - Standardize env var naming (Task ID: 2)
+
+## Sandbox
+- SSH: ssh AbC123xyz@ssh.app.daytona.io
+- ID: abc12345-...
+
+## Setup
+ssh AbC123xyz@ssh.app.daytona.io
+cd /home/daytona
+/usr/bin/git clone https://$GH_TOKEN@github.com/spences10/ralph-town.git
+cd ralph-town
+/usr/bin/git config user.email "claude@anthropic.com"
+/usr/bin/git config user.name "Claude"
+/usr/bin/git checkout -b docs/104-standardize-env-vars
+
+## Implementation
+Standardize on GH_TOKEN everywhere. Search and replace GITHUB_PAT.
+
+Files to update:
+- CLAUDE.md
+- .env.example
+- Any references in docs/
+
+## After Completing
+1. /usr/bin/git add -A && /usr/bin/git commit -m "docs: standardize on GH_TOKEN"
+2. /usr/bin/git push -u origin docs/104-standardize-env-vars
+3. /usr/bin/gh pr create --title "docs: standardize env var naming" --body "Fixes #104"
+4. Mark task #2 completed + send PR URL to team-lead
+```
+
+## Key Points
+
+1. **$GH_TOKEN in clone URL** - Uses env var injected into sandbox
+2. **Explicit file paths** - Tell teammate which files to modify
+3. **Clear implementation** - Describe what to change, not just the problem
+4. **Full paths always** - /usr/bin/git, not git

--- a/.claude/skills/teammate-prompt/references/variables.md
+++ b/.claude/skills/teammate-prompt/references/variables.md
@@ -1,0 +1,46 @@
+# Template Variables
+
+## Required Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{{NAME}}` | Teammate name | fix-98 |
+| `{{TEAM}}` | Team name | ralph-town-fixes |
+| `{{TASK_ID}}` | Task list ID | 1 |
+| `{{ISSUE_NUM}}` | GitHub issue number | 98 |
+| `{{ISSUE_TITLE}}` | Brief description | SSH tokens exposed in JSON |
+| `{{SSH_TOKEN}}` | SSH access token | TS24aga1jLt47Hm7iwvDs8 |
+| `{{SANDBOX_ID}}` | Sandbox UUID | ded60781-9e71-4fd9-81f9-05f60154f786 |
+| `{{REPO}}` | Full repo path | spences10/ralph-town |
+| `{{REPO_NAME}}` | Repo name only | ralph-town |
+| `{{BRANCH}}` | Branch name | fix/98-redact-ssh-tokens |
+| `{{TASK_DESCRIPTION}}` | Implementation details | Add --show-secrets flag... |
+| `{{COMMIT_MSG}}` | Commit message | fix: redact SSH tokens |
+| `{{PR_TITLE}}` | PR title | fix: redact SSH tokens in JSON |
+
+## Getting Variable Values
+
+### SSH Token & Sandbox ID
+
+```bash
+# Create sandbox (GH_TOKEN injected into sandbox env)
+source .env
+ralph-town sandbox create --snapshot ralph-town-dev --env "GH_TOKEN=$GH_TOKEN" --json
+# Returns: {"id":"...", "state":"started"}
+
+# Get SSH token
+ralph-town sandbox ssh <sandbox-id> --json
+# Returns: {"token":"...", "command":"ssh ..."}
+```
+
+### Branch Naming
+
+- `fix/{{ISSUE_NUM}}-{{brief-description}}` - Bug fixes
+- `feat/{{ISSUE_NUM}}-{{brief-description}}` - Features
+- `docs/{{ISSUE_NUM}}-{{brief-description}}` - Documentation
+
+## Important Notes
+
+1. **GH_TOKEN in sandbox** - Token is injected via `--env`, teammate uses `$GH_TOKEN` inside sandbox
+2. **Never pass literal tokens** - Use sandbox env vars, not hardcoded values
+3. **SSH token != GH_TOKEN** - SSH token is for Daytona access, GH_TOKEN is for GitHub


### PR DESCRIPTION
## Summary
- Template for spawning teammates with consistent sandbox instructions
- Prevents common mistakes: local fs writes, missing fail-fast, wrong paths
- Uses $GH_TOKEN from sandbox env (not literal tokens)

## Files
- `.claude/skills/teammate-prompt/SKILL.md` - Core template
- `references/variables.md` - Template variables
- `references/examples.md` - Complete examples

## Lessons from dogfooding session
1. Teammates without explicit "sandbox-only" rule wrote to local filesystem
2. Weak fail-fast instruction ("do NOT retry") was ignored
3. Literal tokens in prompts = security risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)