### PR TITLE
fix: pin SDK to exact version 0.138.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@daytonaio/sdk": "^0.138.0",
+		"@daytonaio/sdk": "0.138.0",
 		"citty": "^0.2.0",
 		"dotenv": "^17.2.3"
 	},


### PR DESCRIPTION
## Summary
- Pin @daytonaio/sdk to exact version 0.138.0 (remove ^ caret)
- Prevents automatic minor/patch updates that could introduce breaking changes

Fixes #114

## Test plan
- [ ] Verify package.json shows `"@daytonaio/sdk": "0.138.0"` without caret

Generated with [Claude Code](https://claude.com/claude-code)