### PR TITLE
feat: add test framework with bun test

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
 	"scripts": {
 		"build": "tsc",
 		"dev": "bun src/index.ts",
+		"test": "bun test",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	parse_int_flag,
+	shell_escape,
+	validate_branch_name,
+} from '../core/utils';
+
+describe('shell_escape', () => {
+	test('escapes single quotes', () => {
+		expect(shell_escape("it's")).toBe("'it'\\''s'");
+	});
+
+	test('wraps simple string in single quotes', () => {
+		expect(shell_escape('hello')).toBe("'hello'");
+	});
+
+	test('handles empty string', () => {
+		expect(shell_escape('')).toBe("''");
+	});
+
+	test('prevents command injection with semicolon', () => {
+		const malicious = 'foo; rm -rf /';
+		const escaped = shell_escape(malicious);
+		expect(escaped).toBe("'foo; rm -rf /'");
+		expect(escaped).not.toContain(';rm');
+	});
+
+	test('prevents command injection with backticks', () => {
+		const malicious = '`whoami`';
+		const escaped = shell_escape(malicious);
+		expect(escaped).toBe("'`whoami`'");
+	});
+
+	test('prevents command injection with $(...)', () => {
+		const malicious = '$(cat /etc/passwd)';
+		const escaped = shell_escape(malicious);
+		expect(escaped).toBe("'$(cat /etc/passwd)'");
+	});
+
+	test('handles multiple single quotes', () => {
+		expect(shell_escape("a'b'c")).toBe("'a'\\''b'\\''c'");
+	});
+});
+
+describe('validate_branch_name', () => {
+	test('accepts valid simple branch name', () => {
+		expect(validate_branch_name('main')).toBe(true);
+		expect(validate_branch_name('feature-branch')).toBe(true);
+		expect(validate_branch_name('fix/issue-123')).toBe(true);
+	});
+
+	test('accepts alphanumeric with dots', () => {
+		expect(validate_branch_name('v1.0.0')).toBe(true);
+		expect(validate_branch_name('release.2024')).toBe(true);
+	});
+
+	test('accepts underscores', () => {
+		expect(validate_branch_name('feature_name')).toBe(true);
+	});
+
+	test('rejects path traversal with ..', () => {
+		expect(validate_branch_name('../etc/passwd')).toBe(false);
+		expect(validate_branch_name('feature/../main')).toBe(false);
+		expect(validate_branch_name('..hidden')).toBe(false);
+	});
+
+	test('rejects spaces', () => {
+		expect(validate_branch_name('my branch')).toBe(false);
+	});
+
+	test('rejects special characters', () => {
+		expect(validate_branch_name('branch;rm -rf')).toBe(false);
+		expect(validate_branch_name('branch`whoami`')).toBe(false);
+		expect(validate_branch_name('branch$(cmd)')).toBe(false);
+		expect(validate_branch_name("branch'name")).toBe(false);
+	});
+
+	test('rejects empty string', () => {
+		expect(validate_branch_name('')).toBe(false);
+	});
+});
+
+describe('parse_int_flag', () => {
+	test('returns default when value undefined', () => {
+		expect(parse_int_flag(undefined, 'count', 10)).toBe(10);
+	});
+
+	test('parses valid integer', () => {
+		expect(parse_int_flag('42', 'count', 10)).toBe(42);
+	});
+
+	test('parses zero', () => {
+		expect(parse_int_flag('0', 'count', 10)).toBe(0);
+	});
+
+	test('parses negative numbers', () => {
+		expect(parse_int_flag('-5', 'count', 10)).toBe(-5);
+	});
+
+	test('throws on NaN string', () => {
+		expect(() => parse_int_flag('abc', 'count', 10)).toThrow(
+			'Invalid value for --count: "abc" is not a number',
+		);
+	});
+
+	test('throws on empty string', () => {
+		expect(() => parse_int_flag('', 'count', 10)).toThrow(
+			'is not a number',
+		);
+	});
+
+	test('throws on float string', () => {
+		expect(() => parse_int_flag('3.14', 'count', 10)).not.toThrow();
+		expect(parse_int_flag('3.14', 'count', 10)).toBe(3);
+	});
+
+	test('respects min constraint', () => {
+		expect(() => parse_int_flag('5', 'count', 10, 10)).toThrow(
+			'--count must be >= 10',
+		);
+		expect(parse_int_flag('10', 'count', 10, 10)).toBe(10);
+	});
+
+	test('respects max constraint', () => {
+		expect(() => parse_int_flag('100', 'count', 10, 0, 50)).toThrow(
+			'--count must be <= 50',
+		);
+		expect(parse_int_flag('50', 'count', 10, 0, 50)).toBe(50);
+	});
+
+	test('handles very large numbers', () => {
+		const big = '9999999999999999999';
+		expect(parse_int_flag(big, 'count', 10)).toBe(
+			parseInt(big, 10),
+		);
+	});
+});

--- a/packages/cli/src/__tests__/validation.test.ts
+++ b/packages/cli/src/__tests__/validation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	SandboxNameValidationError,
+	validate_sandbox_name,
+} from '../sandbox/validation';
+
+describe('validate_sandbox_name', () => {
+	test('accepts valid simple names', () => {
+		expect(() => validate_sandbox_name('sandbox')).not.toThrow();
+		expect(() => validate_sandbox_name('my-sandbox')).not.toThrow();
+		expect(() => validate_sandbox_name('sandbox123')).not.toThrow();
+	});
+
+	test('accepts single character name', () => {
+		expect(() => validate_sandbox_name('a')).not.toThrow();
+		expect(() => validate_sandbox_name('1')).not.toThrow();
+	});
+
+	test('accepts max length name (63 chars)', () => {
+		const maxName = 'a'.repeat(63);
+		expect(() => validate_sandbox_name(maxName)).not.toThrow();
+	});
+
+	test('rejects empty string', () => {
+		expect(() => validate_sandbox_name('')).toThrow(
+			SandboxNameValidationError,
+		);
+		expect(() => validate_sandbox_name('')).toThrow(
+			'at least 1 character',
+		);
+	});
+
+	test('rejects names exceeding 63 characters', () => {
+		const longName = 'a'.repeat(64);
+		expect(() => validate_sandbox_name(longName)).toThrow(
+			SandboxNameValidationError,
+		);
+		expect(() => validate_sandbox_name(longName)).toThrow(
+			'at most 63 characters',
+		);
+	});
+
+	test('rejects names starting with hyphen', () => {
+		expect(() => validate_sandbox_name('-sandbox')).toThrow(
+			SandboxNameValidationError,
+		);
+		expect(() => validate_sandbox_name('-sandbox')).toThrow(
+			'cannot start or end with a hyphen',
+		);
+	});
+
+	test('rejects names ending with hyphen', () => {
+		expect(() => validate_sandbox_name('sandbox-')).toThrow(
+			SandboxNameValidationError,
+		);
+	});
+
+	test('rejects names with special characters', () => {
+		expect(() => validate_sandbox_name('sand_box')).toThrow(
+			SandboxNameValidationError,
+		);
+		expect(() => validate_sandbox_name('sand.box')).toThrow(
+			SandboxNameValidationError,
+		);
+		expect(() => validate_sandbox_name('sand box')).toThrow(
+			SandboxNameValidationError,
+		);
+		expect(() => validate_sandbox_name('sand/box')).toThrow(
+			SandboxNameValidationError,
+		);
+	});
+
+	test('rejects command injection attempts', () => {
+		expect(() => validate_sandbox_name('box;rm -rf')).toThrow(
+			SandboxNameValidationError,
+		);
+		expect(() => validate_sandbox_name('box`whoami`')).toThrow(
+			SandboxNameValidationError,
+		);
+		expect(() => validate_sandbox_name('$(cat /etc)')).toThrow(
+			SandboxNameValidationError,
+		);
+	});
+
+	test('case insensitive pattern allows uppercase', () => {
+		expect(() => validate_sandbox_name('MyBox')).not.toThrow();
+		expect(() => validate_sandbox_name('SANDBOX')).not.toThrow();
+	});
+});


### PR DESCRIPTION
## Summary
- Add `bun test` script to package.json
- Add tests for `shell_escape`, `validate_branch_name`, `parse_int_flag` (command injection, path traversal, edge cases)
- Add tests for `validate_sandbox_name` (valid/invalid patterns)

Fixes #97

## Test plan
- [x] `bun test` passes (34 tests, 58 assertions)

Generated with [Claude Code](https://claude.ai/code)